### PR TITLE
Add translation placeholders note in writing style article

### DIFF
--- a/docs/_articles/writing-style.md
+++ b/docs/_articles/writing-style.md
@@ -10,6 +10,7 @@ The rules are:
 - Always make punctuation part of the translated string (so that RTL languages don't start with a period, for example).
 - Use real ellipsis character (<code>…</code>) rather than three periods (<code>...</code>)<sup>1</sup>.
 - Remember that our name is capitalized like this: `KoboToolbox`.
+- For translated text with placeholders, please use a descriptive text and wrap it in double hashes. E.x. In `Do you live in ##country name## right now?` the placeholder is `##country name##`.
 
 If in doubt, please mimic what is already there.
 

--- a/docs/_articles/writing-style.md
+++ b/docs/_articles/writing-style.md
@@ -10,7 +10,7 @@ The rules are:
 - Always make punctuation part of the translated string (so that RTL languages don't start with a period, for example).
 - Use real ellipsis character (<code>…</code>) rather than three periods (<code>...</code>)<sup>1</sup>.
 - Remember that our name is capitalized like this: `KoboToolbox`.
-- For translated text with placeholders, please use a descriptive text and wrap it in double hashes. E.x. In `Do you live in ##country name## right now?` the placeholder is `##country name##`.
+- For translated text with placeholders, please use a descriptive text and wrap it in double hashes. E.g. for `Do you live in ##country name## right now?` the placeholder is `##country name##`.
 
 If in doubt, please mimic what is already there.
 


### PR DESCRIPTION
New rule on placeholders in translated text.

Part of kobotoolbox/kpi#3651